### PR TITLE
Use Pandoc to convert Word to Markdown.

### DIFF
--- a/RI Data Report/2014_2_28-data_catalogue_report.md
+++ b/RI Data Report/2014_2_28-data_catalogue_report.md
@@ -1,0 +1,608 @@
+Data Report
+
+A brief compilation of data sets available on state agency and other websites
+
+as of February 2014
+
+Compiled by RI Statewide Planning Program
+
+*Introduction*
+
+The RI Division of Planning is a 2011 recipient of a Sustainable Communities Regional Planning Grant from HUD. One of the issues the Division would like to tackle through this grant and beyond is getting a handle on all the data resources currently available in the state: where they live, how they are maintained, how they are accessed, used, and analyzed, and how they are shared with others. Ultimately, we would love to see a central clearinghouse for statewide data (or a clear data network “map”) through which we could share our resources among our offices, and with the municipalities and the general public. Over time as specific data sharing needs arise, we hope to start formalizing relationships with other state agencies and organizations, building on the cooperative work and agreements that have already been shared in the state. In the meantime, we are looking for ways to build relationships among data professionals throughout the state, to encourage more and better networking and collaboration.
+
+*Table of Contents*
+
+City of Providence Department of Public Safety Page 3
+
+HousingWorks Page 4
+
+Narragansett Bay Page 6
+
+The Providence Plan Page 7
+
+Rhode Island Board of Governor’s for Higher Education Page 8
+
+Rhode Island Coastal Resources Management Council Page 9
+
+Rhode Island Department of Business Regulation Page 10
+
+Rhode Island Department of Corrections Page 11
+
+Rhode Island Department of Elementary and Secondary
+
+Education Page 12
+
+Rhode Island Department of Environmental Management Page 13
+
+Rhode Island Department of Health Page 14
+
+Rhode Island Department of Labor and Training Page 15
+
+Rhode Island Department of Revenue Page 17
+
+Rhode Island Department of Transportation Page 18
+
+Rhode Island Geographical Information Systems (RIGIS) Page 19
+
+Rhode Island Housing Page 20
+
+Rhode Island State Council on the Arts Page 21
+
+University of Rhode Island – Environmental Data Center Page 22
+
+U.S. Environmental Protection Agency Office of
+
+Research and Development Page 23
+
+Watershed Counts Page 23*
+City of Department of Public Safety*
+
+The City of Providence Department of Public Safety informs the residents of about key public safety initiatives. The website serves as a threshold to access information from the Department of Public Safety Commissioner’s Office, the Communications Department, the Providence Emergency Management Agency and the Office of Homeland Security, the Providence Fire Department, and the Providence Police Department.
+
+-   Types of Disasters
+
+    -   <http://www.providenceri.com/PEMA/types-of-disasters>
+
+    -   This link provides residents with possible disasters that could occur in the city, what to expect, and how to prepare.
+
+-   Reports and Publications
+
+    -   <http://www.providenceri.com/PEMA/reports-publications>
+
+    -   Emergency plans are listed, but are not available to view. Links to FEMA websites are available, where you can search to view specific city plans.
+
+-   Crime Map
+
+    -   <http://www.providenceri.com/police/crime-map>
+
+    -   The Providence Police Department (PPD) offers free information on crime in city neighborhoods through a third-party website, CrimeReports.com. This tool maps, dates, and categorizes crimes reported throughout the city.
+
+-   Crime Statistics
+
+    -   <http://www.providenceri.com/police/crime-statistics>
+
+    -   PPD posts weekly statistics of crime in the city, breaks them down by neighborhood, and compares them to the statistics of previous years.
+
+-   Daily Arrest Log
+
+    -   <http://www.providenceri.com/police/daily-arrest-log>
+
+    -   This describes arrest status and other details. Information is available for up to a week from the date of arrest.
+
+-   Daily Case Log
+
+    -   <http://www.providenceri.com/police/daily-case-log>
+
+    -   This is available through the month, and gives information on the type of crime, location, and status of arrest.
+
+*HousingWorks *
+
+HousingWorks RI is a coalition of more than 140 organizations working to ensure that all Rhode Islanders have a quality, affordable home—an essential component of our state’s economy. Its members include banks, builders, chambers of commerce, colleges, community-based agencies and advocates, faith groups, manufacturers, preservationists, realtors, municipal officials and unions and more.
+
+-   Housing Fact Book
+
+    -   <http://www.housingworksri.org/cities-towns>
+
+    -   HousingWorks’ biggest project is the Housing Fact Book, which is where data is collected for each town and city in the state. The annual publication provides data analysis on housing affordability and foreclosure rates, and also tries to address overall housing challenges that people of face. This publication dissects the cost of living in different communities, taking the average private-sector wage for the community and the amount that is required to own a house and the average rent for a 2-bedroom apartment. It also provides foreclosure information, and housing unit information.
+
+-   Resources For…
+
+    -   Developers:
+
+    -   <http://www.housingworksri.org/affordable-homes/resources/developers>
+
+    -   Planners:
+
+    -   <http://www.housingworksri.org/affordable-homes/resources/town-planners>
+
+    -   Home Buyers:
+
+    -   <http://www.housingworksri.org/affordable-homes/resources/buyers>
+
+    -   Affordable Housing Committees
+
+    -   <http://www.housingworksri.org/affordable-homes/resources/committees>
+
+*Narragansett Bay*
+
+NarrBay.org is a portal for researchers interested in Narragansett Bay, Rhode Island and contains information on the bay and coastal ecosystems. NarrBay is home to specialized coastal and marine datasets, which can be downloaded in a variety of formats.
+
+The webserver contains:
+
+-   Map gallery, including internet-based and static maps
+
+-   Data download, including biological, chemical, physical, and miscellaneous
+
+-   Bay Conditions, including bay weather, ports and tide charts
+
+-   Bay projects, including NBEP trends, Nu shuttle, Ocean SAMP, plankton time series, RIWINDS, and water quality buoys
+
+Note that this is housed by the URI Environmental Data Center (see page 22)
+*The Plan*
+
+The Providence Plan’s mission is to improve the economic and social well being of , its residents, and its neighborhoods. They provide data analysis for government agencies and community groups throughout the state on a variety of issues, such as economic development, public safety, health, jobs, and education. They also operate programs focused on children’s well being, workforce development, and the capacity of 's nonprofit sector. 
+
+-   Community Profiles
+
+    -   <http://profiles.provplan.org/profiles/state/rhode-island/overview>
+
+    -   The Providence Plan has just recently updated its Community Profiles mapping tool, including a series of comprehensive maps and data for communities across . This tool allows users to zoom to a city, town, neighborhood, census tract, etc. level and view data related to that geography on topics such as demographics, housing, environment, economy and more. This tool is updated with information collected from the U.S. Census and American Community Survey.
+
+-   Historic Aerial Mapping
+
+    -   <http://mapper.provplan.org/ha>
+
+    -   Other information available on The Providence Plan’s website includes a historic mapping tool that displays how our state has evolved over time. Maps date between 1939 and 2011.
+
+-   Property Mapper
+
+    -   <http://mapper.provplan.org/property>
+
+    -   Maps information on property ownership, zoning, foreclosures, lead exposure, and derelict status for the city of .
+
+-   RI DataHUB
+
+    -   <http://ridatahub.org/>
+
+    -   The DataHUB links together data from national, state, and local sources. Topics include: demographics, education, health, adolescent risk factors, adolescent protective factors. The HUB offers summary information in interactive reports and data stories. Data are available for download and for visualization in an online graphing/mapping tool.
+
+ *Board of Governors for Higher Education*
+
+The Board is the state’s legal entity for public higher education. It oversees operations at , College, and . The mission statement is to “provide an excellent, efficient, accessible, and affordable system of higher educational attainment of Rhode Islanders and thereby enrich the intellectual, economic, social, and cultural life of the state, its residents, and its communities.” Most recent information available on the website is from 2009.
+
+-   Higher Education 2009 Fall Enrollment Highlights
+
+    -   <http://www.ribghe.org/fallenroll10.pdf>
+
+    -   Provides highlights and discrepancies in fall enrollment of public and private institutions in 2009.
+
+-   Higher Education 2009 Fall Enrollment by Racial/Ethnic Group Highlights
+
+    -   <http://www.ribghe.org/enrollrace10.pdf>
+
+    -   Provides analysis on racial profiles enrolled in educational institutions in the state.
+
+-   Higher Education 2009 Degrees and Certificates Conferred
+
+    -   <http://www.ribghe.org/degcert10.pdf>
+
+    -   Provides analysis of degrees and certificates conferred in 2009.
+
+-   Performance Indicators for Public Higher Education in
+
+    -   <http://www.ribghe.org/perfindicators2009.pdf>
+
+    -   Provides a comprehensive, in-depth analysis of public higher education institutions in , with information on entering students, tuition, transfer rates, student retention, and completion.
+
+*Rhode Island Coastal Resources Management Council*
+
+The Board is the state’s legal entity for public higher education. It oversees operations at , College, and . The mission statement is to “provide an excellent, efficient, accessible, and affordable system of higher educational attainment of Rhode Islanders and thereby enrich the intellectual, economic, social, and cultural life of the state, its residents, and its communities.” Most recent information available on the website is from 2009.
+
+Maps and data currently on the CRMC site (http://www.crmc.ri.gov/maps.html) include:
+
+-   [RI Coastal Barrier Resources System Index and Maps](http://www.crmc.ri.gov/maps/RI_CBRS_Maps.pdf)
+
+-   [Maps of Water Use Categories](http://www.crmc.ri.gov/maps/maps_wateruse.html)
+
+-   [Shoreline Change Maps](http://www.crmc.ri.gov/maps/maps_shorechange.html)
+
+-   [Freshwater Wetland Jurisdiction](http://www.dem.ri.gov/maps/wetjuris.htm)
+
+-   [RIAI Aquaculture, Fisheries and Habitat Map Server](http://www.edc.uri.edu/fish/)
+
+*
+Rhode Island Department of Business Regulation*
+
+The Department of Business Regulation’s (DBR) primary responsibility is the implementation of state laws mandating the regulation and licensing of designated businesses, professions, occupations, and other specific activities. DBR has different divisions, each focusing on a specific sector of regulation.
+
+-   Banking Regulation Division
+
+    -   <http://www.dbr.ri.gov/divisions/banking/>
+
+    -   Banking Regulation oversees state-chartered financial institutions, credit unions, and licensees. The website lists all financial institutions in the state, as well as enforcement cases and outcomes between 2009 and 2012.
+
+-   Insurance Regulation Division
+
+    -   <http://www.dbr.ri.gov/divisions/insurance/>
+
+    -   The Insurance Regulation Division is responsible for monitoring insurance companies that have clients in the state. This division tracks and verifies insurance license information of businesses and individual professionals. Information on enforcement rulings is available between 2005 and 2012.
+
+-   Securities Regulation Division
+
+    -   <http://www.dbr.ri.gov/divisions/securities/>
+
+    -   Responsible for the registration of certain securities, the licensing and regulation of broker deals, sales representatives, and certain investment advisor representatives. Information provided on this website includes the ability to check securities firms or brokers, investment advisors, and enforcement cases dating back to 2005.
+
+-   Commercial Licensing Division
+
+    -   <http://www.dbr.ri.gov/divisions/commlicensing/>
+
+    -   Responsible for licensing and regulation of real estate agents, brokers and appraisers, auto body & salvage re-builder shops, auto wrecking & salvage yards, upholsterers, auctioneers, liquor wholesalers, breweries, wineries, salespersons & agents, Class G license holders, line-cleaners, and mobile & manufactured homes & parks. All enforcement material since 2011.
+
+-   Division of Design Professionals
+
+    -   <http://www.bdp.state.ri.us/>
+
+    -   A division with four boards of registration regulating licensing of design firms and professionals; architects, landscape architects, engineers, and land surveyors. The website lists registered professionals and firms as well as enforcement actions related to regulation.
+
+*Rhode Island Department of Correction’s Planning and Research Unit*
+
+The Planning and Research Unit organizes, coordinates and supervises short-range and long-range planning functions relating to the Department of Corrections. The unit provides supervision, support and coordination of Departmental program initiatives, program development, program evaluation, and statistical analysis.
+
+The Unit also coordinates and supervises grant solicitations, technical assistance requests, and the management and supervision of projects relating to the Department of Justice’s grant programs. There are a myriad of ‘clients’ for whom the Unit provides assistance including, but not limited to:
+
+Criminal justice agencies such as the courts, Office of Attorney General, Office of Public Defender and Dept of Children, Youth, & Families Governor’s Office Correctional agencies in other jurisdictions Federal and State government criminal justice agencies Private sector criminal justice-related agencies
+
+The unit also provides prison impact statements to the General Assembly for proposed legislation that may impact on the operations of the Department and produces inmate population projections for the budget development process. Lastly, Planning and Research responds to Federal, State and private surveys and serves as a resource for RIDOC personnel and public research requests.
+
+-   Offender Statistics and Reports
+
+    -   Monthly Offender Statistics & Reports
+
+    -   Institutional & Community Confinement Population
+
+    -   Probation & Parole Population
+
+-   Annual Offender Statistics & Reports
+
+    -   Annual Population reports
+
+    -   Population Update reports
+
+    -   Urinalysis Reports
+
+    -   Admissions & Releases
+
+-   Miscellaneous Statistics & Reports
+
+-   Offender Mapping - All maps created by Providence Plan Prior to 2010
+
+<http://www.doc.ri.gov/administration/planning/statistics_reports.php>
+
+-    *Rhode Island Department of Elementary and Secondary Education*
+
+The mission of the Department of Elementary and Secondary Education (RIDE) is “to lead and support schools and communities in ensuring that all students achieve at the high levels needed to lead fulfilling and productive lives, to compete in academic and employment settings, and to contribute to society.” 
+
+.
+
+-   DataWorks!
+
+    -   <http://www.ride.ri.gov/DataWorks>
+
+    -   RIDE’s data website, information on school, district, and state performance reports are available.
+
+-   Frequently Requested Educational Data (FRED)
+
+    -   <http://www.ride.ri.gov/Applications/fred.aspx>
+
+    -   RIDE provides access to all data that has been frequently requested in the past.
+
+-   DataDictionary
+
+    -   <https://www.eride.ri.gov/eRide40/DataDictionary/Default.aspx>
+
+    -   Somewhat difficult to navigate to from RIDE’s home page, the DataDictionary is one of the Department’s largest database collections.
+
+-   InfoWorks!
+
+    -   <http://infoworks.ride.ri.gov>
+
+    -   InfoWorks! Provides a user-friendly template to sift through report data provided by RIDE, which can be broken down into five categories; Student Achievement, Teaching, Family and Community Characteristics, Safe and Supportive Schools, and Funding and Resources.
+
+*Rhode Island Department of Environmental Management*
+
+DEM uses Geographic Information System (GIS) technology to create, manipulate and analyze spatial data that help us achieve our mission of preserving the quality of Rhode Island's environment.
+
+-   Interactive Digital Map resources
+
+    -   Environmental Resource Map
+
+    -   Topograph map and aerial photo viewer
+
+-   Paper Map resources
+
+    -   CRMC/DEM Wetland Regulatory Jurisdiction
+
+    -   DEM Groundwater Classification and Wellhead Protection Area Maps
+
+    -   Shellfish Grounds, Closures and Approved Areas
+
+    -   Shellfish Tagging: Narragansett Bay
+
+    -   DEM Management & Hunting Area Atlas
+
+    -   Snake Den State Park Hunting Boundary Maps
+
+    -   Lake and Pond Bathymetry Maps for Fishermen
+
+    -   Marine Sanitation Device: No Discharge Zone for RI Waters
+
+    -   Marine Sanitation Device: Pumpout Facilities
+
+    -   RI Critical Resource Atlas Exit DEM site flag
+
+    -   RIPDES Phase II Stormwater Requirement Areas
+
+    -   RI Environmental Sensitivity Index Maps Exit DEM site flag
+
+    -   RI Marine Resource Uses Exit DEM site flag
+
+    -   RI Resource Protection Project Exit DEM site flag
+
+    -   South County Greenspace Project Maps
+
+    -   United States Library of Congress Map Collection Exit DEM site flag
+
+    -   RI Watersheds with HUC12 Sub-Watersheds
+        *Rhode Island Department of Health*
+
+The primary mission of the Rhode Island Department of Health (DOH) is to prevent disease and to protect and promote the health and safety of the people of . DOH coordinates public health information and activities throughout the state.
+
+-   Health Data Inventory
+
+    -   <http://www.health.ri.gov/publications/datareports/2008HealthDataInventory.pdf>
+
+    -   A compilation of "most" data sets available through DOH (the 2008 version did not include all datasets). This inventory is currently being updated and will be an interactive online system that will include all datasets operated and managed by the RI Department of Health. It will serve as a resource for identifying data sources including their uses, target populations, health indicators and reports. The target date for completion is February 2014.
+
+-   Climate Change
+
+    -   Future Social and Economic Loss and Health Impacts Due to Extreme Weather Events and Sea-Level Rise (October 25, 2013): <http://www.health.ri.gov/materialbyothers/2014FutureHealthImpactsFromClimateChangeInRhodeIslandEvidenceFromClimate.pdf>
+
+    -   Future Health Impacts from Climate Change in Rhode Island:
+
+> Evidence from Climate Models (October 25, 2013): http://www.health.ri.gov/materialbyothers/2014FutureSocialAndEconomicLossAndHealthImpactsDueTOExtremeWeatherEventsAndSeaLevelRise.pdf
+
+*Rhode Island Department of Labor and Training*
+
+Department of Labor and Training (DLT) reports on employment statistics of the state, and has a formal file sharing agreement with the Bureau of Labor Statistics, the Census Bureau, and the Employment & Training Administration. Most of the information they produce is kept up-to-date and available on their website.
+
+-   Current Employment Statistics
+
+    -   <http://www.dlt.ri.gov/lmi/ces.htm>
+
+    -   Estimates the current number of jobs at businesses, and tracks changes in employment from the prior month and year.
+
+-   Local Area Unemployment Statistics
+
+    -   <http://www.dlt.ri.gov/lmi/laus.htm>
+
+    -   Provides information on the number of residents employed, unemployed, and in the labor force, as well as the unemployment rate for the state. It is used to help describe changes in the state and local economies for policy makers and other interested parties.
+
+-   Quarterly Census on Employment and Wages
+
+    -   <http://www.dlt.ri.gov/lmi/es202.htm>
+
+    -   Provides data on employment and wages by detailed industry, which helps gauge the economic progress and job creation of the quarter. It is used for unemployment insurance and tax purposes, and for benchmarking the current employment statistics once a year.
+
+-   Occupational Employment Statistics
+
+    -   <http://www.dlt.ri.gov/lmi/oes.htm>
+
+    -   Provides employment data by occupation to report on what various occupations pay; demand for different occupations; which occupations pay the most; and which industries employ certain occupations.
+
+-   Mass Layoff Statistics
+
+    -   <http://www.dlt.ri.gov/lmi/mls.htm>
+
+    -   Produced to show which employers have laid off 50 or more people over a five-week period, this information helps track employers facing cutbacks and can help provide early warning signs of economic problems.
+
+-   Industry and Occupational Projections
+
+    -   <http://www.dlt.ri.gov/lmi/proj.htm>
+
+    -   Projections of employment by industry and occupation for a ten-year period. Collected every two years, this information helps those investing in job development better target training dollars into growing industries and occupations as well as providing a guide to students in career planning.
+
+-   Unemployment Insurance Administrative Data
+
+    -   <http://www.dlt.ri.gov/lmi/uiadmin.htm>
+
+    -   Provides demographic information on those applying for unemployment insurance, as well as those who are currently collecting benefits and those who are exhausting the program.
+
+-   The Local Employment Dynamics
+
+    -   <http://www.dlt.ri.gov/lmi/led.htm>
+
+    -   Consists of eight quarterly workforce indicators that provide data on employment and measures of change, such as job flows, turnover, new hires, separations, and average earnings. The data set also includes a web-based mapping and reporting application that shows where workers are employed and where they live. It also provides companion reports on age, earnings, industry distribution, and local workforce indicators by geography ranging from census block to state.
+
+-   Employee Benefits Survey
+
+    -   <http://www.dlt.ri.gov/lmi/ebs.htm>
+
+    -   A biennial survey of some 2,000 employers on the kinds of benefits they offer their employees.
+
+*Rhode Island Department of Revenue*
+
+The mission of the Department of Revenue is to administer and collect revenues under its jurisdiction in a manner that is fair, equitable, and timely, while enforcing applicable state and federal laws; to monitor actual revenues compared to enacted estimates and advise the Governor and General Assembly on revenue matters; to enforce applicable state and federal laws relating to the licensing of drivers, vehicle safety, emissions guidelines, and commercial driving; and to monitor the fiscal health of local governments and work with municipalities to preserve fiscal health and assist in times of stress.
+
+-   Reports
+
+    -   <http://www.dor.ri.gov/Reports/index.php>
+
+    -   The Department of Revenue makes tax reports available to the public on its website. Resident and Non-Resident Reports from 2005 to 2010; Corporate Reports from 2008 to 2010; Tax Expenditures from 2011 and 2012; and Tax Credit Reports from 2008 to 2012. All can be used when determining the state’s income stream, as well as available tax credits and the businesses that have taken advantage of them. Some of this information seems to be updated on an annual basis, but most of the tax reports are not up to date.
+
+*Rhode Island Department of Transportation*
+
+The mission of the Rhode Island Department of Transportation (RIDOT) is to maintain and provide a safe, efficient, environmentally, aesthetically and culturally sensitive intermodal transportation network that offers a variety of convenient, cost-effective mobility opportunities for people and the movement of goods supporting economic development and improved quality of life.
+
+-   Transportation 2030
+
+    -   <http://www.planning.ri.gov/transportation/trans2030.pdf>
+
+    -   The department prepares a long-range transportation plan that is part of the State Guide Plan, a collection of plans and policy documents adopted by the State Planning Council that addresses the social, economic, and physical development of the state. The last transportation plan was adopted in 2004, and was valid through 2025. Federal regulations for ozone non-attainment areas, such as , require an updated plan every four years. This plan includes a long-range framework that is laid out for all transportation oriented projects to be addressed. The newest update is to be released soon.
+
+-   Intermodal Planning
+
+    -   <http://www.dot.ri.gov/intermodal/index.asp>
+
+    -   RIDOT is working towards creating a state that is more easily traversable by public transportation options; their primary focus is on rail and their partnership with the Massachusetts Bay Transportation Authority (MBTA). All the information on their website available on this topic is accessible through the ‘Intermodal Planning’ tab.
+
+*Geographic Information System*
+
+A geographic information system (GIS) is an organizational structure, suite of hardware/software, technical tools, maps, and geographically related databases. A GIS can be used to capture, manage, assimilate, analyze, and depict spatially related information in a variety of ways for any number of disciplines. 
+
+The Rhode Island Geographic Information System (RIGIS) is a consortium of government entities, academic institutions, and private organizations that employ GIS technology and use geospatial information.
+
+The mission of RIGIS is to monitor, coordinate, and provide leadership for activities related to the use of geographic information system technology in , and to support initiatives to implement or use this technology.
+
+-   Main Website with Calendar of Upcoming Events:
+
+    -   <http://www.edc.uri.edu/rigis/>
+
+    -   The RIGIS data distribution system is hosted by the University of Rhode Island Environmental Data Center, and is maintained by the URI Geospatial Extension Program.
+
+<!-- -->
+
+-   Data Download:
+
+    -   <http://www.edc.uri.edu/rigis/data/>
+
+    -   The RIGIS database consists of several hundred individual spatial databases, or data sets, in vector (point, line, polygon) and raster image format. Although originally conceived and built as an information system for the state's coastal and terrestrial natural resource data, it presently includes extensive data in many disciplines.
+
+-   RI Digital Atlas:
+
+    -   <http://www.arcgis.com/home/group.html?owner=URIEDC&title=Rhode%20Island%20Digital%20Atlas>
+
+    -   The purpose of this website is to connect you with easy-to-use online maps of . These maps have been designed to facilitate mash-ups, use with online web mapping applications, and Esri ArcGIS products.
+
+<!-- -->
+
+-   Five-Year Strategic Plan:
+
+    -   <http://www.edc.uri.edu/rigis/about/docs/2011/20110818-RIGIS5YearStrategicPlan-FINAL.DOC.pdf>
+
+    -   The purpose of this strategic planning document is to provide a direction for the future development and use of Geographic Information Systems **(GIS)** in for the period from July1, 2011 through June 30, 2016.
+
+*Housing*
+
+Rhode Island Housing (RIH), a self-sustaining public agency, helps customers rent, buy, and retain homes. RIH uses all of its resources to provide low-interest loans, grants, education, and assistance to help the people of find, rent, buy, build, and keep a quality home.
+
+-   Five-Year Strategic Plan
+
+    -   <http://www.rhodeislandhousing.org/filelibrary/2006-2010SSHP.pdf>
+
+    -   The Five-Year Strategic Plan (2010-2015) encompasses the work that RIH plans to complete.
+
+-   The Comprehensive Annual Performance and Evaluation Report
+
+    -   <http://www.rhodeislandhousing.org/filelibrary/CAPER_PY2011_FINAL.pdf>
+
+    -   The Comprehensive Annual Performance and Evaluation Report (CAPER) tracks progress on implementing the Strategic Plan. It is updated annually, and helps form the Annual Action Plan for the next year.
+
+-   Annual Action Plan
+
+    -   <http://www.rhodeislandhousing.org/filelibrary/AAP_PY2013_FINAL.pdf>
+
+    -   The Annual Action plan pulls from the CAPER and the Five-Year Strategic Plan to outline what is to be completed in the coming year.
+
+-   Rent Survey
+
+    -   <http://www.rhodeislandhousing.org/filelibrary/YE2011_Rent-Survey.pdf>
+
+    -   Provides average rents for the year, and compares them to the previous year.
+
+-   Change in Average Rents
+
+    -   <http://www.rhodeislandhousing.org/filelibrary/2001-2011_Rents_ANALYSIS.pdf>
+
+    -   Graph shows change in average rents over ten-year period.
+
+*Rhode Island State Council on the Arts*
+
+The Rhode Island Cultural Data Project (Rhode Island CDP) “offers a powerful online management tool designed to strengthen arts and cultural organizations. This groundbreaking project gathers reliable, longitudinal data on the sector.”
+
+The information provided in this map is based on aggregate data supplied by arts and cultural organizations participating in the CDP. With more organizations completing their CDP Data Profiles every day and more states joining every year, the map’s data will be updated regularly.
+
+The interactive map includes data on the whole of the USA, including RI on the following:
+
+-   Budget
+
+-   Total revenue
+
+-   Earned revenue
+
+-   Contributed
+
+-   Expenses
+
+-   Attendance
+
+-   Workforce
+
+-   Events
+
+http://www.riculturaldata.org/home.aspx
+*U.S. Environmental Protection Agency (EPA) Office of Research and Development*
+
+EPA provides great deal of information on their website, which is relatively easy to navigate. The primary resource for data useful to may be found in the Methods, Models, Tools, and Databases section, which catalogues data from EPA’s various research and projects. Each link has a quick sentence to describe what information the user will find in the document.
+
+This site also has information about different issues regarding the environment. For example, a great deal of information is available on climate change, including links to specific sections of the country with tailored climate change impacts and remedies.
+
+Useful Link: <http://www.epa.gov/ord/mmtd/index.htm>
+
+*
+University of Rhode Island – Environmental Data Center*
+
+The Environmental Data Center is the center of technical expertise in GIS for the state of Rhode Island. The (EDC) is a Geographic Information System (GIS) and spatial data analysis laboratory in the University of Rhode Island's Department of Natural Resources Science, College of the Environment and Life Science. Major areas of research at the EDC are spatial data modeling, ecological mapping, and data integration for environmental applications.
+
+The mission of the EDC is to support the use of contemporary tools of spatial data processing and electronic dissemination in the analysis and distribution of environmental data. This is achieved through collaborative research with faculty in the Department of Natural Resources Science and projects with agencies external to URI.
+
+The Rhode Island Geographic Information Systems (RIGIS) database is stored at the EDC. The RIGIS database is the most comprehensive and detailed of any state in the country and contains information on almost all aspects of Rhode Island's natural and cultural resources (e.g., wetlands, aquifers, soils, forests, land use, topography, historic sites, etc.).
+
+Current projects and initiatives include:
+
+-   Broadband Rhode Island
+
+-   Geospatial Extension Program
+
+-   Global Positioning System (GPS) Basestation
+
+-   Large Marine Ecosystems
+
+-   MapCoast
+
+-   Marine Wildlife Behavior Database
+
+-   NarrBay.org (see also, page 6)
+
+-   National Park Service Field Technical Support Center
+
+-   National Park Service National Resource Condition Assessment Center
+
+-   National Park Service Sea Level Rise and Monumentation
+
+-   North Atlantic Coast Cooperative Ecosystem Studies Unit
+
+-   Renewable Resources Extension Act (RREA) Program
+
+-   Rhode Island Army National Guard GIS Support
+
+-   Rhode Island Digital Atlas
+
+-   Rhode Island Geographic Information System (RIGIS)
+
+More information at: http://www.edc.uri.edu/initiatives
+*Watershed Counts*
+
+Watershed Counts is comprised of a diverse partnership between agencies and organizations that have committed to work together to examine and report regularly on the condition of the land and water resources in the Narragansett Bay Watershed Region.
+
+Useful Link: [www.watershedcounts.org](http://www.watershedcounts.org)


### PR DESCRIPTION
In the spirit of doing things the GitHub, open way, I converted the Data Catalogue Report Word doc to GitHub-flavored Markdown using [Pandoc](http://pandoc.org/). 

This is a like-for-like automated conversion. The document itself needs some cleanup, but I just wanted something quick and dirty. I left RI_Data_Report and the root Word doc in here in case something went horribly wrong in conversion, but it looks ok to me in my cursory glance. 
